### PR TITLE
If fromInterval and untilInterval is the same during fetch return pre…

### DIFF
--- a/whisper.go
+++ b/whisper.go
@@ -746,6 +746,11 @@ func (whisper *Whisper) Fetch(fromTime, untilTime int) (timeSeries *TimeSeries, 
 		return &TimeSeries{fromInterval, untilInterval, step, values}, nil
 	}
 
+	// Zero-length time range: always include the next point
+	if fromInterval == untilInterval {
+		untilInterval += archive.SecondsPerPoint()
+	}
+
 	fromOffset := archive.PointOffset(baseInterval, fromInterval)
 	untilOffset := archive.PointOffset(baseInterval, untilInterval)
 

--- a/whisper_test.go
+++ b/whisper_test.go
@@ -338,6 +338,15 @@ func TestCreateUpdateFetch(t *testing.T) {
 
 }
 
+// Test for a bug in python whisper library: https://github.com/graphite-project/whisper/pull/136
+func TestCreateUpdateFetchOneValue(t *testing.T) {
+	var timeSeries *TimeSeries
+	timeSeries = testCreateUpdateFetch(t, Average, 0.5, 3500, 3500, 1, 300, 0.5, 0.2)
+	if len(timeSeries.values) > 1 {
+		t.Fatalf("More then one point fetched\n")
+	}
+}
+
 func BenchmarkCreateUpdateFetch(b *testing.B) {
 	path, _, archiveList, tearDown := setUpCreate()
 	var err error


### PR DESCRIPTION
…vious datapoint

This was fixed in python whisper library here:
https://github.com/graphite-project/whisper/pull/136

Make go code behave the same in the same case.
